### PR TITLE
Fix parameters not loaded and  vc.ril.camera

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,21 @@
 cmake_minimum_required(VERSION 3.5)
 project(raspicam2)
 
-set(CMAKE_CXX_STANDARD 14)
+# Default to C99
+if(NOT CMAKE_C_STANDARD)
+  set(CMAKE_C_STANDARD 99)
+endif()
+
+# Default to C++14
+if(NOT CMAKE_CXX_STANDARD)
+  set(CMAKE_CXX_STANDARD 14)
+endif()
+
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  add_compile_options(-Wall -Wextra -Wpedantic)
+endif()
+
+set (CMAKE_SHARED_LINKER_FLAGS "-Wl,--no-as-needed")
 
 find_package(ament_cmake REQUIRED)
 find_package(rclcpp REQUIRED)

--- a/src/RasPiCamPublisherNode.cpp
+++ b/src/RasPiCamPublisherNode.cpp
@@ -6,6 +6,42 @@ RasPiCamPublisher::RasPiCamPublisher(rclcpp::NodeOptions options)
 
     configure_parameters(*state);
 
+    //declare all parameters
+    declare_parameter("width");
+    declare_parameter("height");
+    declare_parameter("fps");
+    declare_parameter("quality");
+    declare_parameter("image_transport");
+    declare_parameter("enable_imv");
+    declare_parameter("camera_id");
+    declare_parameter("sharpness");
+    declare_parameter("contrast");
+    declare_parameter("brightness");
+    declare_parameter("saturation");
+    declare_parameter("ISO");
+    declare_parameter("videoStabilisation");
+    declare_parameter("exposureCompensation");
+    // declare_parameter("exposureMode");
+    // declare_parameter("flickerAvoidMode");
+    // declare_parameter("exposureMeterMode");
+    // declare_parameter("awbMode");
+    // declare_parameter("imageEffect");
+    declare_parameter("colourEffects_enable");
+    declare_parameter("colourEffects_u");
+    declare_parameter("colourEffects_v");
+    declare_parameter("rotation");
+    declare_parameter("hflip");
+    declare_parameter("vflip");
+    declare_parameter("roi_x");
+    declare_parameter("roi_y");
+    declare_parameter("roi_w");
+    declare_parameter("roi_h");
+    declare_parameter("shutter_speed");
+    declare_parameter("awb_gains_r");
+    declare_parameter("awb_gains_b");
+    declare_parameter("analog_gain");
+    declare_parameter("digital_gain");
+
     // get parameters
     int w, h, f, q;
     get_parameter_or("width", w, 320);


### PR DESCRIPTION
Fixes:
-parameters not loaded because not declared
-runtime error at init (vc.ril.camera not found) probably because of CMake optimization

Fixes #8. Fixes #9.